### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/getApiKeys.yml
+++ b/.github/workflows/getApiKeys.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   debug:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nicmart-dev/feedmenow/security/code-scanning/1](https://github.com/nicmart-dev/feedmenow/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only reads secrets and does not perform any write operations, we will set `contents: read` as the minimal required permission. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
